### PR TITLE
actionsをv2からv3に編集

### DIFF
--- a/.github/workflows/qiita_sync.yml
+++ b/.github/workflows/qiita_sync.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.9'
       - name: Install qiita-sync
@@ -23,7 +23,7 @@ jobs:
       - name: Run qiita-sync
         run: |
           qiita_sync sync .
-        env: 
+        env:
           QIITA_ACCESS_TOKEN: ${{ secrets.QIITA_ACCESS_TOKEN }}
       - name: Git
         run: |

--- a/.github/workflows/qiita_sync_check.yml
+++ b/.github/workflows/qiita_sync_check.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.9'
       - name: Install qiita-sync
@@ -28,5 +28,5 @@ jobs:
           qiita_sync check . > ./qiita_sync_output.txt
           cat ./qiita_sync_output.txt
           [ ! -s "qiita_sync_output.txt" ] || exit 1
-        env: 
+        env:
           QIITA_ACCESS_TOKEN: ${{ secrets.QIITA_ACCESS_TOKEN }}


### PR DESCRIPTION
## 修正したい現象の再現手順
テンプレートから自分のGitHubへリポジトリを作成し、手順通りに進めていくとGitHub Actionsのところでエラーが発生した。

## 現時点で得られる結果
Qiita Syncおよび、Qiita Sync Checkを実行したら以下のエラーが発生する。
```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

## 本来期待される結果
Qiita Syncおよび、Qiita SyncCheckの実行とQiita記事の同期

## 考えられる原因
2022年9月をもってGitHub ActionsでNode.js v12の非推奨化プロセスが始まりました。
[Node.js v12に依存する`actions/checkout@v2`などは`v3`へ移行する必要があります。](https://qiita.com/masato_makino/items/3edde8e5f1a782a5c7ea#%E5%BF%85%E8%A6%81%E3%81%AA%E5%AF%BE%E5%87%A6)